### PR TITLE
Switch to AHash{Map,Set}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,6 +382,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +437,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 name = "jar_verifier"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "binrw",
  "clap",
  "env_logger",
@@ -425,6 +451,7 @@ dependencies = [
 name = "java_class"
 version = "0.4.0"
 dependencies = [
+ "ahash",
  "binrw",
  "glob",
  "log",
@@ -577,12 +604,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
@@ -610,7 +643,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -619,6 +652,7 @@ dependencies = [
 name = "reference_checker"
 version = "0.3.2"
 dependencies = [
+ "ahash",
  "binrw",
  "java_class",
  "log",
@@ -777,6 +811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +957,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.11.6"
 log = { version = "0.4.26", features = ["release_max_level_debug"] }
 clap = { version = "4.5.31", features = ["derive"] }
 rayon = "1.10.0"
+ahash = "0.8.12"
 
 [workspace]
 resolver = "2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+disallowed-types = ["std::collections::HashMap", "std::collections::HashSet"]

--- a/src/checking/reference_checker/Cargo.toml
+++ b/src/checking/reference_checker/Cargo.toml
@@ -10,3 +10,4 @@ java_class = { path = "../../parsing/java_class/" }
 binrw = "0.15.0"
 rayon = "1.10.0"
 log = "0.4.26"
+ahash = "0.8.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,9 @@
 
 mod args;
 mod error;
-use std::{collections::HashMap, fs::File, io::Write};
+use std::{fs::File, io::Write};
 
+use ahash::AHashMap;
 use args::Args;
 use clap::Parser;
 use env_logger::Env;
@@ -21,6 +22,8 @@ use log::{debug, info, trace};
 use reference_checker::{ClassDependencies, check_classes};
 
 use crate::error::ArgError;
+
+type HashMap<K, V> = AHashMap<K, V>;
 
 fn main() -> Result<(), error::Error> {
     env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
@@ -39,7 +42,7 @@ fn main() -> Result<(), error::Error> {
 
     #[cfg(feature = "embedded_classinfo")]
     let embedded_classinfo: HashMap<u16, &'static str> = {
-        let mut map = HashMap::new();
+        let mut map = HashMap::default();
         map.insert(11, include_str!("../data/11.classinfo"));
         map.insert(17, include_str!("../data/17.classinfo"));
         map.insert(21, include_str!("../data/21.classinfo"));
@@ -112,7 +115,7 @@ fn format(dep: Vec<ClassDependencies>) -> String {
 }
 
 fn read_classinfo(data: &str) -> Result<HashMap<&str, ClassInfo<'_>>, error::Error> {
-    let mut result = HashMap::new();
+    let mut result = HashMap::default();
     let java_classes =
         classinfo::ClassInfo::from_string(data).expect("Failed to read classinfo file!");
     for class_info in java_classes {

--- a/src/parsing/java_class/Cargo.toml
+++ b/src/parsing/java_class/Cargo.toml
@@ -20,3 +20,4 @@ zip = { version = "8.0.0", default-features = false, features = [
 log = "0.4.26"
 rayon = "1.10.0"
 nom = "8.0.0"
+ahash = "0.8.12"

--- a/src/parsing/java_class/src/classinfo.rs
+++ b/src/parsing/java_class/src/classinfo.rs
@@ -6,8 +6,7 @@
 * SPDX-License-Identifier: MPL-2.0
 */
 
-use std::collections::HashMap;
-
+use ahash::AHashMap;
 use nom::{
     IResult, Parser,
     bytes::complete::{tag, take_till},
@@ -18,6 +17,8 @@ use nom::{
 };
 
 use log::trace;
+
+type HashMap<K, V> = AHashMap<K, V>;
 
 #[derive(Debug)]
 pub struct ClassInfo<'a> {

--- a/src/parsing/java_class/src/java_class.rs
+++ b/src/parsing/java_class/src/java_class.rs
@@ -6,12 +6,16 @@
 * SPDX-License-Identifier: MPL-2.0
 */
 
-use std::collections::{HashMap, HashSet};
 use std::io::{Read, Seek};
 
+use ahash::AHashMap;
+use ahash::AHashSet;
 use binrw::BinReaderExt;
 use binrw::prelude::*;
 use modular_bitfield_msb::prelude::*;
+
+type HashMap<K, V> = AHashMap<K, V>;
+type HashSet<E> = AHashSet<E>;
 
 #[binread]
 #[derive(Debug)]


### PR DESCRIPTION
Profiling showed that the hot path was mostly hashing, so using a faster hash implementation (default is SipHash) for all the sets and maps has a pretty big impact, especially when running fewer threads.

Some non-representative results using `time` (time in seconds):

| Impl     | 4 Threads | 32 Threads |
| ----------- | ----------- | ----------- |
| Default (SipHash)  | 17.981 | 4.625 |
| FxHash   | 6.239 | 2.495 |
| AHash   | 6.375 | 2.485 |

Based on these results, it's a tossup between FxHash and AHash. I went with AHash because it is specifically for in-memory maps and at least tries to be somewhat DoS-resistant.