### PR TITLE
feat: Structured Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ The output can be roughly described by the following grammar:
 
 ```
 ClassRequirements := ClassName Requirement+
-Requirement       := <TAB>(ClassImport|MethodImport)
-ClassImport       := "Class " ClassName
-MethodImport      := ("ClassMethod "|"IfaceMethod ") MethodSpec
+Requirement       := <TAB>ClassImport
+ClassImport       := ("Class" | "Interface") ClassName ["(API mismatch)"] MethodImport+
+MethodImport      := <TAB>"Method " MethodSpec
 MethodSpec        := ClassName "#" MethodName MethodDescriptor
 ```
 

--- a/src/checking/reference_checker/src/lib.rs
+++ b/src/checking/reference_checker/src/lib.rs
@@ -477,10 +477,7 @@ pub fn check_classes<'a>(
     Some(result)
 }
 
-fn get_consumed(
-    classes: &HashMap<String, Class>,
-    parallel: bool,
-) -> HashSet<ClassDependencies<'_>> {
+fn get_consumed(classes: &HashMap<String, Class>, parallel: bool) -> HashSet<ClassDependencies<'_>> {
     if parallel {
         classes
             .par_iter()

--- a/src/checking/reference_checker/src/lib.rs
+++ b/src/checking/reference_checker/src/lib.rs
@@ -21,9 +21,18 @@ type HashSet<E> = AHashSet<E>;
 
 struct ClassRequirements<'a> {
     name: &'a str,
-    classes: Vec<&'a str>,
-    class_methods: Vec<(&'a str, String)>,
-    iface_methods: Vec<(&'a str, String)>,
+    dependencies: HashMap<&'a str, Dependency>,
+}
+
+struct Dependency {
+    methods: Vec<String>,
+    is_interface: bool,
+}
+
+impl Dependency {
+    fn add(&mut self, method: String) {
+        self.methods.push(method);
+    }
 }
 
 trait Consumer<'a> {

--- a/src/checking/reference_checker/src/lib.rs
+++ b/src/checking/reference_checker/src/lib.rs
@@ -67,13 +67,16 @@ impl PartialEq for ClassRequirements<'_> {
 
 impl<'a> ClassRequirements<'a> {
     #[allow(dead_code)]
-    fn remove_class(&mut self, class: &str) {
+    fn remove_class(&mut self, class: &'a str) {
         trace!("Removing class {} from {}", class, self.name);
-        self.dependencies.remove(class);
+        if let Entry::Occupied(mut o) = self.dependencies.entry(class) {
+            o.get_mut().class_dep = false;
+        }
     }
 
     fn clear_empty_deps(&mut self) {
-        self.dependencies.retain(|_, dep| !dep.methods.is_empty());
+        self.dependencies
+            .retain(|_, dep| dep.class_dep || !dep.methods.is_empty());
     }
 
     fn remove_methods<'b>(
@@ -102,9 +105,8 @@ impl<'a> ClassRequirements<'a> {
         self.clear_empty_deps();
     }
 
-    fn remove_java_classes_and_methods(&mut self, java_classes: &HashMap<&str, ClassInfo>) {
-        self.dependencies
-            .retain(|name, _| !java_classes.contains_key(name));
+    fn remove_java_classes_and_methods(&mut self, java_classes: &HashMap<&'a str, ClassInfo>) {
+        java_classes.keys().for_each(|cls| self.remove_class(cls));
         for (class_name, dep) in self.dependencies.iter_mut() {
             dep.methods
                 .retain(|method| !Self::provides_method(class_name, method, java_classes));
@@ -199,6 +201,7 @@ impl<'a> ClassRequirements<'a> {
 struct Dependency {
     methods: HashSet<String>,
     is_interface: bool,
+    class_dep: bool,
 }
 
 impl Dependency {
@@ -276,6 +279,7 @@ impl<'a> Consumer<'a> for Class {
                 .or_insert(Dependency {
                     methods: HashSet::new(),
                     is_interface: false,
+                    class_dep: false,
                 })
                 .add(method);
         }
@@ -284,8 +288,18 @@ impl<'a> Consumer<'a> for Class {
                 .or_insert(Dependency {
                     methods: HashSet::new(),
                     is_interface: true,
+                    class_dep: false,
                 })
                 .add(method);
+        }
+        for cls in class_imports {
+            deps.entry(cls)
+                .or_insert(Dependency {
+                    methods: HashSet::new(),
+                    is_interface: false,
+                    class_dep: true,
+                })
+                .class_dep = true;
         }
         Ok(ClassRequirements {
             name: this_name,
@@ -361,6 +375,7 @@ fn collect_methods(
     if let Some(current_class) = classes.get(class_name) {
         trace!("Class {}", class_name);
         for method_signature in current_class.get_methods()? {
+            trace!("Method {} in {}", method_signature, class_name);
             result.insert(
                 method_signature.clone(),
                 Method::new(method_signature.clone()),
@@ -405,7 +420,7 @@ fn collect_methods(
 pub fn check_classes<'a>(
     classes: &'a HashMap<String, Class>,
     parallel: bool,
-    java_classes: &HashMap<&str, ClassInfo>,
+    java_classes: &HashMap<&'a str, ClassInfo>,
 ) -> Option<HashSet<ClassRequirements<'a>>> {
     info!("Checking class dependencies");
     let provided = get_provided(classes, parallel, java_classes);
@@ -422,17 +437,21 @@ pub fn check_classes<'a>(
     if parallel {
         dependencies.par_iter_mut().for_each(|dep| {
             for (class, method_provider) in &provided {
-                dep.remove_methods(class, &method_provider.methods);
-                // dep.remove_class(class); TODO figure out how to handle standalone missing
-                // methods (e.g. Class is present, but has different API)
+                if dep.dependencies.contains_key(class) {
+                    dep.remove_methods(class, &method_provider.methods);
+                    dep.remove_class(class);
+                }
+                dep.clear_empty_deps();
             }
         });
     } else {
         for dep in dependencies.iter_mut() {
             for (class, method_provider) in &provided {
-                dep.remove_methods(class, &method_provider.methods);
-                // dep.remove_class(class); TODO figure out how to handle standalone missing
-                // methods (e.g. Class is present, but has different API)
+                if dep.dependencies.contains_key(class) {
+                    dep.remove_methods(class, &method_provider.methods);
+                    dep.remove_class(class);
+                }
+                dep.clear_empty_deps();
             }
         }
     }

--- a/src/checking/reference_checker/src/lib.rs
+++ b/src/checking/reference_checker/src/lib.rs
@@ -79,11 +79,8 @@ impl<'a> ClassRequirements<'a> {
             .retain(|_, dep| dep.class_dep || !dep.methods.is_empty());
     }
 
-    fn remove_methods<'b>(
-        &mut self,
-        class: &'a str,
-        methods: &'b HashMap<String, Method>,
-    ) where
+    fn remove_methods<'b>(&mut self, class: &'a str, methods: &'b HashMap<String, Method>)
+    where
         'a: 'b,
     {
         trace!(
@@ -172,24 +169,25 @@ impl<'a> ClassRequirements<'a> {
         sorted.sort_by_key(|&(name, _)| name);
         for entry in sorted {
             result.push('\t');
-            result.push_str(format!("Class {}", entry.0).as_str());
+            let cls = format!(
+                "{} {}",
+                if entry.1.is_interface {
+                    "Interface"
+                } else {
+                    "Class"
+                },
+                entry.0
+            );
+            result.push_str(cls.as_str());
+            if !entry.1.class_dep {
+                result.push_str(" (API mismatch)");
+            }
             result.push('\n');
             let mut sorted: Vec<&'a str> = entry.1.methods.iter().map(|s| s.as_str()).collect();
             sorted.sort();
             for method in sorted {
                 result.push_str("\t\t");
-                result.push_str(
-                    format!(
-                        "{}Method {}",
-                        if entry.1.is_interface {
-                            "Iface"
-                        } else {
-                            "Class"
-                        },
-                        method
-                    )
-                    .as_str(),
-                );
+                result.push_str(format!("Method {}", method).as_str());
                 result.push('\n');
             }
         }

--- a/src/checking/reference_checker/src/lib.rs
+++ b/src/checking/reference_checker/src/lib.rs
@@ -19,19 +19,191 @@ use rayon::prelude::*;
 type HashMap<K, V> = AHashMap<K, V>;
 type HashSet<E> = AHashSet<E>;
 
-struct ClassRequirements<'a> {
+#[derive(Debug, Eq)]
+pub struct ClassRequirements<'a> {
     name: &'a str,
     dependencies: HashMap<&'a str, Dependency>,
 }
 
+impl PartialOrd for ClassRequirements<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+
+    fn lt(&self, other: &Self) -> bool {
+        self.name.lt(other.name)
+    }
+
+    fn le(&self, other: &Self) -> bool {
+        self.name.le(other.name)
+    }
+
+    fn gt(&self, other: &Self) -> bool {
+        self.name.gt(other.name)
+    }
+
+    fn ge(&self, other: &Self) -> bool {
+        self.name.ge(other.name)
+    }
+}
+
+impl Ord for ClassRequirements<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(other.name)
+    }
+}
+
+impl Hash for ClassRequirements<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(self.name.as_bytes());
+    }
+}
+
+impl PartialEq for ClassRequirements<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl<'a> ClassRequirements<'a> {
+    #[allow(dead_code)]
+    fn remove_class(&mut self, class: &str) {
+        trace!("Removing class {} from {}", class, self.name);
+        self.dependencies.remove(class);
+    }
+
+    fn clear_empty_deps(&mut self) {
+        self.dependencies.retain(|_, dep| !dep.methods.is_empty());
+    }
+
+    fn remove_methods<'b>(
+        &mut self,
+        class: &'a str,
+        methods: &'b HashMap<String, Method>,
+    ) where
+        'a: 'b,
+    {
+        trace!(
+            "Removing methods {:?} of class {} from {}",
+            methods, class, self.name
+        );
+        let entry = self.dependencies.entry(class);
+
+        if let Entry::Occupied(mut e) = entry {
+            let value = &mut e.get_mut().methods;
+            for sig in methods.keys() {
+                trace!("Trying to remove {}#{}", class, sig.as_str());
+                if value.remove(sig) {
+                    trace!("Removed {}#{}", class, sig.as_str());
+                    trace!("Remaining methods for {}: {:?}", class, value);
+                }
+            }
+        }
+        self.clear_empty_deps();
+    }
+
+    fn remove_java_classes_and_methods(&mut self, java_classes: &HashMap<&str, ClassInfo>) {
+        self.dependencies
+            .retain(|name, _| !java_classes.contains_key(name));
+        for (class_name, dep) in self.dependencies.iter_mut() {
+            dep.methods
+                .retain(|method| !Self::provides_method(class_name, method, java_classes));
+        }
+        self.clear_empty_deps();
+    }
+
+    fn provides_method(class: &str, method: &str, java_classes: &HashMap<&str, ClassInfo>) -> bool {
+        if let Some(class_info) = java_classes.get("java/lang/Object")
+            && !method.contains("<init>")
+            && class_info.methods.contains_key(method)
+        {
+            return true;
+        }
+        if let Some(class_info) = java_classes.get(class) {
+            if class_info.methods.contains_key(method) {
+                return true;
+            }
+            if class_info.methods.values().any(|m| m.polymorphic_signature) {
+                let Some((method_name, _)) = method.split_once("(") else {
+                    panic!("Illegal method signature! {}", method)
+                };
+                for class_method in class_info.methods.values().filter_map(|m| {
+                    if m.polymorphic_signature {
+                        let Some((name, _)) = method.split_once("(") else {
+                            panic!("Illegal method signature! {}", method)
+                        };
+                        return Some(name);
+                    }
+                    None
+                }) {
+                    if method_name == class_method {
+                        return true;
+                    }
+                }
+            }
+            if let Some(super_class) = class_info.super_class
+                && Self::provides_method(super_class, method, java_classes)
+            {
+                return true;
+            }
+            for super_iface in &class_info.interfaces {
+                if Self::provides_method(super_iface, method, java_classes) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.dependencies.is_empty()
+    }
+
+    pub fn format(&'a self) -> String {
+        let mut result = self.name.to_owned();
+        result.push('\n');
+        let mut sorted: Vec<(&'a str, &Dependency)> = self
+            .dependencies
+            .iter()
+            .map(|(name, dep)| (*name, dep))
+            .collect();
+        sorted.sort_by_key(|&(name, _)| name);
+        for entry in sorted {
+            result.push('\t');
+            result.push_str(format!("Class {}", entry.0).as_str());
+            result.push('\n');
+            let mut sorted: Vec<&'a str> = entry.1.methods.iter().map(|s| s.as_str()).collect();
+            sorted.sort();
+            for method in sorted {
+                result.push_str("\t\t");
+                result.push_str(
+                    format!(
+                        "{}Method {}",
+                        if entry.1.is_interface {
+                            "Iface"
+                        } else {
+                            "Class"
+                        },
+                        method
+                    )
+                    .as_str(),
+                );
+                result.push('\n');
+            }
+        }
+        result
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
 struct Dependency {
-    methods: Vec<String>,
+    methods: HashSet<String>,
     is_interface: bool,
 }
 
 impl Dependency {
     fn add(&mut self, method: String) {
-        self.methods.push(method);
+        self.methods.insert(method);
     }
 }
 
@@ -97,11 +269,27 @@ impl<'a> Consumer<'a> for Class {
                 }
             }
         }
+
+        let mut deps = HashMap::new();
+        for (cls, method) in required_class_methods {
+            deps.entry(cls)
+                .or_insert(Dependency {
+                    methods: HashSet::new(),
+                    is_interface: false,
+                })
+                .add(method);
+        }
+        for (cls, method) in required_iface_methods {
+            deps.entry(cls)
+                .or_insert(Dependency {
+                    methods: HashSet::new(),
+                    is_interface: true,
+                })
+                .add(method);
+        }
         Ok(ClassRequirements {
             name: this_name,
-            classes: class_imports,
-            class_methods: required_class_methods,
-            iface_methods: required_iface_methods,
+            dependencies: deps,
         })
     }
 }
@@ -136,7 +324,6 @@ fn process_method<'a>(
 struct MethodProvider<'a> {
     name: &'a str,
     methods: HashMap<String, Method>,
-    interface: bool,
 }
 
 impl Provider for Class {
@@ -156,7 +343,6 @@ impl Provider for Class {
                 return Ok(Some(MethodProvider {
                     name: class_name,
                     methods: result,
-                    interface: self.is_interface(),
                 }));
             }
             trace!("Skipping module-info.class");
@@ -216,242 +402,18 @@ fn collect_methods(
     Ok(result)
 }
 
-#[derive(Debug, Eq, Clone)]
-pub struct ClassDependencies<'a> {
-    name: &'a str,
-    classes: HashSet<&'a str>,
-    class_methods: HashMap<&'a str, HashSet<String>>,
-    iface_methods: HashMap<&'a str, HashSet<String>>,
-}
-
-impl PartialOrd for ClassDependencies<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-
-    fn lt(&self, other: &Self) -> bool {
-        self.name.lt(other.name)
-    }
-
-    fn le(&self, other: &Self) -> bool {
-        self.name.le(other.name)
-    }
-
-    fn gt(&self, other: &Self) -> bool {
-        self.name.gt(other.name)
-    }
-
-    fn ge(&self, other: &Self) -> bool {
-        self.name.ge(other.name)
-    }
-}
-
-impl Ord for ClassDependencies<'_> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.name.cmp(other.name)
-    }
-}
-
-impl Hash for ClassDependencies<'_> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write(self.name.as_bytes());
-    }
-}
-
-impl PartialEq for ClassDependencies<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-    }
-}
-
-impl<'a> From<ClassRequirements<'a>> for ClassDependencies<'a> {
-    fn from(val: ClassRequirements<'a>) -> Self {
-        let mut class_methods: HashMap<&'a str, HashSet<String>> = HashMap::default();
-        let mut iface_methods: HashMap<&'a str, HashSet<String>> = HashMap::default();
-        let mut classes = HashSet::default();
-        classes.extend(val.classes);
-        for (class, method) in val.class_methods {
-            match class_methods.entry(class) {
-                Entry::Occupied(mut entry) => {
-                    entry.get_mut().insert(method);
-                }
-                Entry::Vacant(entry) => {
-                    let mut set = HashSet::default();
-                    set.insert(method);
-                    entry.insert(set);
-                }
-            };
-        }
-        for (class, method) in val.iface_methods {
-            match iface_methods.entry(class) {
-                Entry::Occupied(mut entry) => {
-                    entry.get_mut().insert(method);
-                }
-                Entry::Vacant(entry) => {
-                    let mut set = HashSet::default();
-                    set.insert(method);
-                    entry.insert(set);
-                }
-            };
-        }
-        ClassDependencies {
-            name: val.name,
-            classes,
-            class_methods,
-            iface_methods,
-        }
-    }
-}
-
-impl<'a> ClassDependencies<'a> {
-    fn remove_class(&mut self, class: &str) {
-        trace!("Removing class {} from {}", class, self.name);
-        self.classes.remove(class);
-    }
-
-    fn clear_empty_deps(&mut self) {
-        self.class_methods.retain(|_, set| !set.is_empty());
-        self.iface_methods.retain(|_, set| !set.is_empty());
-    }
-
-    fn remove_methods<'b>(
-        &mut self,
-        class: &'a str,
-        methods: &'b HashMap<String, Method>,
-        iface: bool,
-    ) where
-        'a: 'b,
-    {
-        trace!(
-            "Removing methods {:?} of class {} from {}",
-            methods, class, self.name
-        );
-        let entry: Entry<'_, _, _> = if iface {
-            self.iface_methods.entry(class)
-        } else {
-            self.class_methods.entry(class)
-        };
-        if let Entry::Occupied(mut e) = entry {
-            let value = e.get_mut();
-            for sig in methods.keys() {
-                trace!("Trying to remove {}#{}", class, sig.as_str());
-                if value.remove(sig) {
-                    trace!("Removed {}#{}", class, sig.as_str());
-                    trace!("Remaining methods for {}: {:?}", class, value);
-                }
-            }
-        }
-        self.clear_empty_deps();
-    }
-
-    fn remove_java_classes_and_methods(&mut self, java_classes: &HashMap<&str, ClassInfo>) {
-        self.classes.retain(|name| !java_classes.contains_key(name));
-        for (class_name, methods) in self.class_methods.iter_mut() {
-            methods.retain(|method| !Self::provides_method(class_name, method, java_classes));
-        }
-        for (iface_name, methods) in self.iface_methods.iter_mut() {
-            methods.retain(|method| !Self::provides_method(iface_name, method, java_classes));
-        }
-        self.clear_empty_deps();
-    }
-
-    fn provides_method(class: &str, method: &str, java_classes: &HashMap<&str, ClassInfo>) -> bool {
-        if let Some(class_info) = java_classes.get("java/lang/Object")
-            && !method.contains("<init>")
-            && class_info.methods.contains_key(method)
-        {
-            return true;
-        }
-        if let Some(class_info) = java_classes.get(class) {
-            if class_info.methods.contains_key(method) {
-                return true;
-            }
-            if class_info.methods.values().any(|m| m.polymorphic_signature) {
-                let Some((method_name, _)) = method.split_once("(") else {
-                    panic!("Illegal method signature! {}", method)
-                };
-                for class_method in class_info.methods.values().filter_map(|m| {
-                    if m.polymorphic_signature {
-                        let Some((name, _)) = method.split_once("(") else {
-                            panic!("Illegal method signature! {}", method)
-                        };
-                        return Some(name);
-                    }
-                    None
-                }) {
-                    if method_name == class_method {
-                        return true;
-                    }
-                }
-            }
-            if let Some(super_class) = class_info.super_class
-                && Self::provides_method(super_class, method, java_classes)
-            {
-                return true;
-            }
-            for super_iface in &class_info.interfaces {
-                if Self::provides_method(super_iface, method, java_classes) {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    fn is_empty(&self) -> bool {
-        self.classes.is_empty() && self.class_methods.is_empty() && self.iface_methods.is_empty()
-    }
-
-    pub fn format(&'a self) -> String {
-        let mut result = self.name.to_owned();
-        result.push('\n');
-        let mut sorted: Vec<&&str> = self.classes.iter().collect();
-        sorted.sort();
-        for class in sorted {
-            result.push('\t');
-            result.push_str(format!("Class {class}").as_str());
-            result.push('\n');
-        }
-        let mut sorted: Vec<(&&str, &HashSet<String>)> = self.class_methods.iter().collect();
-        sorted.sort_unstable_by(|a, b| a.0.cmp(b.0));
-        result.push_str(Self::methods_to_str(&sorted, "ClassMethod").as_str());
-        sorted = self.iface_methods.iter().collect();
-        sorted.sort_unstable_by(|a, b| a.0.cmp(b.0));
-        result.push_str(Self::methods_to_str(&sorted, "IfaceMethod").as_str());
-        result
-    }
-
-    fn methods_to_str(sorted_methods: &Vec<(&&str, &'a HashSet<String>)>, prefix: &str) -> String {
-        let mut result: String = Default::default();
-        for (class, methods) in sorted_methods {
-            let mut sorted: Vec<&String> = methods.iter().collect();
-            sorted.sort();
-            for method in sorted {
-                result.push('\t');
-                result.push_str(format!("{prefix} {class}#{method}").as_str());
-                result.push('\n');
-            }
-        }
-        result
-    }
-}
-
 pub fn check_classes<'a>(
     classes: &'a HashMap<String, Class>,
     parallel: bool,
     java_classes: &HashMap<&str, ClassInfo>,
-) -> Option<HashSet<ClassDependencies<'a>>> {
+) -> Option<HashSet<ClassRequirements<'a>>> {
     info!("Checking class dependencies");
     let provided = get_provided(classes, parallel, java_classes);
-    let mut dependencies: Vec<ClassDependencies<'a>> = Vec::new();
+    let mut dependencies: Vec<ClassRequirements<'a>> = Vec::new();
     dependencies.extend(get_consumed(classes, parallel));
-    let mut dependencies: Vec<ClassDependencies<'a>> = dependencies
-        .iter_mut()
-        .map(|d| {
-            d.remove_java_classes_and_methods(java_classes);
-            d.to_owned()
-        })
-        .collect();
+    for dep in dependencies.iter_mut() {
+        dep.remove_java_classes_and_methods(java_classes);
+    }
     debug!(
         "Provided size {} | Dependencies count {}",
         provided.capacity(),
@@ -460,19 +422,17 @@ pub fn check_classes<'a>(
     if parallel {
         dependencies.par_iter_mut().for_each(|dep| {
             for (class, method_provider) in &provided {
-                if dep.classes.contains(class) {
-                    dep.remove_class(class);
-                    dep.remove_methods(class, &method_provider.methods, method_provider.interface);
-                }
+                dep.remove_methods(class, &method_provider.methods);
+                // dep.remove_class(class); TODO figure out how to handle standalone missing
+                // methods (e.g. Class is present, but has different API)
             }
         });
     } else {
         for dep in dependencies.iter_mut() {
-            for (class, methods) in &provided {
-                if dep.classes.contains(class) {
-                    dep.remove_class(class);
-                    dep.remove_methods(class, &methods.methods, methods.interface);
-                }
+            for (class, method_provider) in &provided {
+                dep.remove_methods(class, &method_provider.methods);
+                // dep.remove_class(class); TODO figure out how to handle standalone missing
+                // methods (e.g. Class is present, but has different API)
             }
         }
     }
@@ -486,11 +446,14 @@ pub fn check_classes<'a>(
     Some(result)
 }
 
-fn get_consumed(classes: &HashMap<String, Class>, parallel: bool) -> HashSet<ClassDependencies<'_>> {
+fn get_consumed(
+    classes: &HashMap<String, Class>,
+    parallel: bool,
+) -> HashSet<ClassRequirements<'_>> {
     if parallel {
         classes
             .par_iter()
-            .map(|(_, class)| Into::<ClassDependencies<'_>>::into(class.get_consumed().unwrap()))
+            .map(|(_, class)| class.get_consumed().unwrap())
             .fold(HashSet::default, |mut a, b| {
                 a.insert(b);
                 a
@@ -502,7 +465,7 @@ fn get_consumed(classes: &HashMap<String, Class>, parallel: bool) -> HashSet<Cla
     } else {
         classes
             .values()
-            .map(|class| Into::<ClassDependencies<'_>>::into(class.get_consumed().unwrap()))
+            .map(|class| class.get_consumed().unwrap())
             .fold(HashSet::default(), |mut a, b| {
                 a.insert(b);
                 a

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use java_class::{
     parse_classpath,
 };
 use log::{debug, info, trace};
-use reference_checker::{ClassDependencies, check_classes};
+use reference_checker::{ClassRequirements, check_classes};
 
 use crate::error::ArgError;
 
@@ -88,7 +88,7 @@ fn main() -> Result<(), error::Error> {
         check_classes(&classes, parallel, &java_classes).expect("Failed to get result");
     info!("Done.");
 
-    let mut sorted: Vec<ClassDependencies<'_>> = Vec::with_capacity(unmet_deps.capacity());
+    let mut sorted: Vec<ClassRequirements<'_>> = Vec::with_capacity(unmet_deps.capacity());
     sorted.extend(unmet_deps);
     sorted.sort();
     if let Some(path) = args.output_file {
@@ -110,7 +110,7 @@ fn write_output(path: &str, content: &str) -> Result<(), error::Error> {
     Ok(())
 }
 
-fn format(dep: Vec<ClassDependencies>) -> String {
+fn format(dep: Vec<ClassRequirements>) -> String {
     let mut result = String::with_capacity(dep.capacity());
     for d in dep {
         result.push_str(d.format().as_str());
@@ -178,7 +178,7 @@ mod test {
 
         let consumed = check_classes(&classes, false, &java_classes).expect("Failed to get result");
 
-        let mut sorted: Vec<ClassDependencies<'_>> = Vec::with_capacity(consumed.capacity());
+        let mut sorted: Vec<ClassRequirements<'_>> = Vec::with_capacity(consumed.capacity());
         sorted.extend(consumed);
         sorted.sort();
 

--- a/testdata/requirements_11.txt
+++ b/testdata/requirements_11.txt
@@ -1,11 +1,11 @@
 org/example/LibraryWithDependencies
 	Class org/apache/commons/math3/distribution/BetaDistribution
-	Class org/apache/commons/math3/distribution/RealDistribution
+		Method <init>(DD)V
+	Interface org/apache/commons/math3/distribution/RealDistribution
+		Method getNumericalMean()D
 	Class org/apache/commons/math3/random/MersenneTwister
+		Method <init>()V
 	Class org/apache/commons/math3/random/UniformRandomGenerator
-	ClassMethod org/apache/commons/math3/distribution/BetaDistribution#<init>(DD)V
-	ClassMethod org/apache/commons/math3/random/MersenneTwister#<init>()V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#<init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#nextNormalizedDouble()D
-	IfaceMethod org/apache/commons/math3/distribution/RealDistribution#getNumericalMean()D
+		Method <init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
+		Method nextNormalizedDouble()D
 

--- a/testdata/requirements_17.txt
+++ b/testdata/requirements_17.txt
@@ -1,11 +1,11 @@
 org/example/LibraryWithDependencies
 	Class org/apache/commons/math3/distribution/BetaDistribution
-	Class org/apache/commons/math3/distribution/RealDistribution
+		Method <init>(DD)V
+	Interface org/apache/commons/math3/distribution/RealDistribution
+		Method getNumericalMean()D
 	Class org/apache/commons/math3/random/MersenneTwister
+		Method <init>()V
 	Class org/apache/commons/math3/random/UniformRandomGenerator
-	ClassMethod org/apache/commons/math3/distribution/BetaDistribution#<init>(DD)V
-	ClassMethod org/apache/commons/math3/random/MersenneTwister#<init>()V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#<init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#nextNormalizedDouble()D
-	IfaceMethod org/apache/commons/math3/distribution/RealDistribution#getNumericalMean()D
+		Method <init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
+		Method nextNormalizedDouble()D
 

--- a/testdata/requirements_21.txt
+++ b/testdata/requirements_21.txt
@@ -1,12 +1,14 @@
 org/example/LibraryWithDependencies
 	Class org/apache/commons/math3/distribution/BetaDistribution
-	Class org/apache/commons/math3/distribution/RealDistribution
+		Method <init>(DD)V
+	Interface org/apache/commons/math3/distribution/RealDistribution
+		Method getNumericalMean()D
 	Class org/apache/commons/math3/random/MersenneTwister
+		Method <init>()V
 	Class org/apache/commons/math3/random/UniformRandomGenerator
-	ClassMethod org/apache/commons/math3/distribution/BetaDistribution#<init>(DD)V
-	ClassMethod org/apache/commons/math3/random/MersenneTwister#<init>()V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#<init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#nextNormalizedDouble()D
-	IfaceMethod org/apache/commons/math3/distribution/RealDistribution#getNumericalMean()D
+		Method <init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
+		Method nextNormalizedDouble()D
 org/example/LibraryWithoutDependencies
-	ClassMethod java/lang/ThreadGroup#allowThreadSuspension(Z)Z
+	Class java/lang/ThreadGroup (API mismatch)
+		Method allowThreadSuspension(Z)Z
+

--- a/testdata/requirements_25.txt
+++ b/testdata/requirements_25.txt
@@ -1,12 +1,14 @@
 org/example/LibraryWithDependencies
 	Class org/apache/commons/math3/distribution/BetaDistribution
-	Class org/apache/commons/math3/distribution/RealDistribution
+		Method <init>(DD)V
+	Interface org/apache/commons/math3/distribution/RealDistribution
+		Method getNumericalMean()D
 	Class org/apache/commons/math3/random/MersenneTwister
+		Method <init>()V
 	Class org/apache/commons/math3/random/UniformRandomGenerator
-	ClassMethod org/apache/commons/math3/distribution/BetaDistribution#<init>(DD)V
-	ClassMethod org/apache/commons/math3/random/MersenneTwister#<init>()V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#<init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
-	ClassMethod org/apache/commons/math3/random/UniformRandomGenerator#nextNormalizedDouble()D
-	IfaceMethod org/apache/commons/math3/distribution/RealDistribution#getNumericalMean()D
+		Method <init>(Lorg/apache/commons/math3/random/RandomGenerator;)V
+		Method nextNormalizedDouble()D
 org/example/LibraryWithoutDependencies
-	ClassMethod java/lang/ThreadGroup#allowThreadSuspension(Z)Z
+	Class java/lang/ThreadGroup (API mismatch)
+		Method allowThreadSuspension(Z)Z
+


### PR DESCRIPTION
## What

The output of the checker now groups the unmet imports by the classes containing them. Where previously all unmet imports were a single list of classes and methods like

```
com/mysql/cj/protocol/x/CompressionSplittedInputStream
        Class com/google/protobuf/ByteString
        Class com/google/protobuf/Parser
        ClassMethod com/google/protobuf/ByteString#toByteArray()[B
        IfaceMethod com/google/protobuf/Parser#parseFrom([B)Ljava/lang/Object;
```

it is now grouped by class:
```
com/mysql/cj/protocol/x/CompressionSplittedInputStream
        Class com/google/protobuf/ByteString
                ClassMethod toByteArray()[B
        Class com/google/protobuf/Parser
                IfaceMethod parseFrom([B)Ljava/lang/Object;
```

## Why

The old format unfortunately gets hard to read when there are a lot of unmet imports (common when some huge library like protobuf is missing), especially because there is no visual relation between the missing classes (always listed at the top due to sorting) and their contained methods. With the new structure, it should be easier to determine which methods belong to which imported class at a glance.

## Caveats

The old format lists standalone missing methods (i.e. method is missing, but the containing class is present (=API mismatch)), whereas the new format necessarily also lists its containing class. The class entry is suffixed with `(API mismatch)` to highlight this. Some odd circumstances are thus more visible, e.g. if a class calls a method of itself but does not define it, like when it extends a superclass which is not found.